### PR TITLE
resizes nav-links on smaller size

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -18,3 +18,9 @@
 .search-form {
   border-radius: 30px;
 }
+
+@media only screen and (max-width: 700px) {
+  .navbar-expand-sm .navbar-nav .nav-link {
+    font-size: 0.7rem;
+  }
+}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_17_214116) do
+ActiveRecord::Schema.define(version: 2020_11_19_215343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,15 @@ ActiveRecord::Schema.define(version: 2020_11_17_214116) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["teacher_id"], name: "index_courses_on_teacher_id"
+  end
+
+  create_table "pg_search_documents", force: :cascade do |t|
+    t.text "content"
+    t.string "searchable_type"
+    t.bigint "searchable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Why?
When screen shrinks the links stay too large
What?
Targeted the navbar links
How? 
Implemented this line into the navbar.scss:
@media only screen and (max-width: 700px) {
  .navbar-expand-sm .navbar-nav .nav-link {
    font-size: 0.7rem;
  }
}
